### PR TITLE
Adds step to pull the autoscale.tick

### DIFF
--- a/labs/07-autoscaling.md
+++ b/labs/07-autoscaling.md
@@ -10,13 +10,18 @@ Create the `app` replicaset:
 kubectl create -f https://raw.githubusercontent.com/kelseyhightower/oscon-metrics-tutorial/master/replicasets/app.yaml
 ```
 
-Create the `app` service
+Create the `app` service:
 
 ```
 kubectl create -f https://raw.githubusercontent.com/kelseyhightower/oscon-metrics-tutorial/master/services/app.yaml
 ```
 
 ## Define and Enable the Autoscale Task
+
+Pull autoscale TICKscript task:
+```
+curl -O https://raw.githubusercontent.com/influxdata/k8s-kapacitor-autoscale/master/autoscale.tick
+```
 
 ```
 kapacitor define autoscale -tick autoscale.tick -type stream -dbrp autoscale.autogen


### PR DESCRIPTION
When just following this document, there is no autoscale.tick script locally available, so step to define kapacitor autoscale fails.
This change adds step to pull the autoscale.tick script from influxdata repo.